### PR TITLE
Automatically create monthly releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,31 @@
+on:
+  push:
+    branches:
+      - master
+
+name: Create Release
+
+jobs:
+  build:
+    name: Create Release
+    runs-on: ubuntu-latest
+    # Run on the 8th of each month
+    if: "endsWith(github.event.head_commit.message, '08')"
+    steps:
+      - name: Get month name
+        env:
+          LAST_COMMIT_LOG: ${{ github.event.head_commit.message }}
+        run: |
+          echo "RELEASE_VERSION=${LAST_COMMIT_LOG: -8:4}.${LAST_COMMIT_LOG: -4:2}" >> $GITHUB_ENV
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Create Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: ${{ format('Monthly release {0}', env.RELEASE_VERSION) }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
  - Runs on the 8th of every month
  - Heavily depends on the current format of commit messages